### PR TITLE
docs: The documentation section is correctly structured

### DIFF
--- a/src/.vuepress/navbar.ts
+++ b/src/.vuepress/navbar.ts
@@ -68,7 +68,16 @@ export const enNavbarConfig = navbar([
         ],
       },
       {
-        text: "Dispositivos",
+        text: "Datos Maestros",
+        children: [
+          "master-data/business-partner",
+          "master-data/product",
+          "master-data/warehouse",
+          "master-data/reports"
+        ],
+      },
+      {
+        text: "Aplicaciones",
         children: [
           "devices/record-weight/",
           "devices/printers",
@@ -92,15 +101,6 @@ export const enNavbarConfig = navbar([
         text: "Otros procedimientos",
         children: [
           "other-process/"
-        ],
-      },
-      {
-        text: "Datos Maestros",
-        children: [
-          "master-data/business-partner",
-          "master-data/product",
-          "master-data/warehouse",
-          "master-data/reports"
         ],
       },
       {

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -28,7 +28,6 @@ Tenga en cuenta que todo el ecosistema [ADempiere ERP](https://erpya.com/) se cr
 - [Accesos Rápidos](basic-rules/quick-access)
 - [Utilería](basic-rules/props)
 
-
 ### Datos Maestros
 
 - [Socio del Negocio](master-data/business-partner)
@@ -36,13 +35,39 @@ Tenga en cuenta que todo el ecosistema [ADempiere ERP](https://erpya.com/) se cr
 - [Almacén](master-data/warehouse)
 - [Reportes de Maestros](master-data/reports)
 
-### Gestión de Materiales
+### Aplicaciones
 
-- [Movimiento de Inventario](material-management/inventory-move)
-- [Inventario de Uso Interno](material-management/internal-use-inventory)
-- [Inventario Físico](material-management/physical-inventory)
-- [Lista de Materiales](material-management/ldm)
-- [Reabastecimiento](material-management/replenishment)
+- [Lectura de Peso](devices/record-weight/)
+- [Impresoras](devices/printers/)
+- [Control de Asistencia](devices/attendance-control/)
+
+### Inicio de Sesión con Keycloak
+
+- [Acceso Seguro con Keycloak](basic-rules/login-keycloak.md)
+- [Keycloak con Autenticación 2FA](basic-rules/login-2fa.md)
+
+### Importaciones
+
+- [Importación de Datos](data-importation/)
+
+### Otros procedimientos
+
+- [Otros Procedimientos](other-process/)
+
+### Gestiones
+
+- [Gestión de Materiales](material-management/)
+- [Gestión de Producción](production-management/)
+- [Gestión de Distribución](distribution-management/)
+- [Gestión de Distribución](sales-management/)
+- [Gestión de Relaciones con Clientes](customer-relationship-management/)
+- [Gestión PDV](pdv-management/)
+- [Gestión de Compras](purchase-management/)
+- [Gestión de Devoluciones](return-management/)
+- [Gestión de Saldos Pendientes](balance-management/)
+- [Gestión de Recursos Humanos](human-management/)
+- [Gestión de Activos](asset-management/)
+- [Gestión Contable](accounting-management/)
 
 ### Verticales de Negocio
 


### PR DESCRIPTION
The navigation bar articles belonging to the "Documentation" section have been added to the main README

Before:
![before](https://github.com/user-attachments/assets/181b9aa1-e991-4ae9-8095-da35a1d97d7a)

---

After:

![after](https://github.com/user-attachments/assets/ce0d2d2f-8886-49b9-ac6a-9028a75a4ae6)
